### PR TITLE
Use google-libphonenumber instead

### DIFF
--- a/lib/pnf.js
+++ b/lib/pnf.js
@@ -1,5 +1,6 @@
 'use strict';
-var libphonenumber = require('libphonenumber')
+var PNF = require('google-libphonenumber').PhoneNumberFormat
+  , phoneUtil = require('google-libphonenumber').phoneUtil
   , readline = require('readline')
   , os = require('os')
   , pnf = {}
@@ -15,7 +16,7 @@ pnf.config = function(config) {
 };
 
 pnf.options = {
-  format: 'e164',
+  format: PNF.E164,
   lang: 'FR'
 };
 
@@ -23,21 +24,17 @@ pnf.numbers = [];
 pnf.help = false;
 
 pnf.format = function(number) {
-  libphonenumber[this.options.format](
-    number,
-    this.options.lang,
-    function(error, result) {
-      if (error) {
-        pnf.stderr.write(
-          number + ' is not a valid number' + os.EOL
-        );
-        return false;
-      }
-      if (result) {
-        pnf.stdout.write(result + os.EOL);
-      }
-    }
-  );
+  var parsedNumber = phoneUtil.parse(number, this.options.lang);
+
+  if (!phoneUtil.isValidNumber(parsedNumber)) {
+    pnf.stderr.write(
+      number + ' is not a valid number' + os.EOL
+    );
+
+    return false;
+  }
+
+  pnf.stdout.write(phoneUtil.format(parsedNumber, this.options.format) + os.EOL);
 };
 
 pnf.args = function(arg) {
@@ -67,11 +64,11 @@ pnf.args = function(arg) {
     case arg === '--intl':
     case arg === '-international':
     case arg === '--international':
-      pnf.options.format = 'intl';
+      pnf.options.format = PNF.INTERNATIONAL;
       break;
     case arg === '-e164':
     case arg === '--e164':
-      pnf.options.format = 'e164';
+      pnf.options.format = PNF.E164;
       break;
     case arg.substr(0,6) === '-lang=':
     case arg.substr(0,7) === '--lang=':

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Sébastien ELET <sebastien@elet.fr>",
   "license": "BSD-2-Clause",
   "dependencies": {
+    "google-libphonenumber": "^0.2.0",
     "libphonenumber": "0.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
I've replaced the existing `libphonenumber` implementation for [google-libphonenumber](https://www.npmjs.org/package/google-libphonenumber), which I currently maintain. The last metadata update from the previous library dates back to June of 2014 (the most recent metadata available is from February of 2015).

`google-libphonenumber` is exactly like the original library but repackaged for node. No additional APIs or methods are exposed. You can read more about [the differences from other forks](https://github.com/seegno/google-libphonenumber#differencies-from-other-forks).

Hope it helps!
